### PR TITLE
feat: JWT Token 인증 구현

### DIFF
--- a/src/main/java/com/prokectB/meongbti/authentication/service/AuthService.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/service/AuthService.java
@@ -1,0 +1,39 @@
+package com.prokectB.meongbti.authentication.service;
+
+import com.prokectB.meongbti.authentication.token.RefreshToken;
+import com.prokectB.meongbti.authentication.token.RefreshTokenProvider;
+import com.prokectB.meongbti.authentication.token.RefreshTokenRepository;
+import com.prokectB.meongbti.authentication.token.TokenProvider;
+import com.prokectB.meongbti.common.exception.notfound.MemberNotFoundException;
+import com.prokectB.meongbti.common.exception.unauthorized.PasswordMismatchException;
+import com.prokectB.meongbti.common.presentation.auth.common.LoginDto;
+import com.prokectB.meongbti.member.entity.Member;
+import com.prokectB.meongbti.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenProvider refreshTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public LoginDto login(String email, String password) {
+        Member loginMember = memberRepository.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
+        if (!passwordEncoder.matches(password, loginMember.getPassword())) {
+            throw new PasswordMismatchException();
+        }
+
+        Long memberId = loginMember.getId();
+        String accessToken = tokenProvider.createAccessToken(memberId);
+        RefreshToken refreshToken = refreshTokenProvider.createToken(memberId);
+        refreshTokenRepository.save(refreshToken);
+        return LoginDto.create(accessToken, refreshToken.getTokenValue());
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/token/AuthTokenExtractor.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/token/AuthTokenExtractor.java
@@ -1,0 +1,24 @@
+package com.prokectB.meongbti.authentication.token;
+
+import com.prokectB.meongbti.common.exception.unauthorized.TokenMalformedException;
+import com.prokectB.meongbti.common.exception.unauthorized.TokenNotExistsException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthTokenExtractor {
+
+    private static final String TOKEN_TYPE = "Bearer";
+
+    public String extractToken(String authorizationHeader) {
+        if (authorizationHeader == null) {
+            throw new TokenNotExistsException();
+        }
+
+        String[] splitHeaders = authorizationHeader.split(" ");
+
+        if (splitHeaders.length != 2 || !splitHeaders[0].equalsIgnoreCase(TOKEN_TYPE)) {
+            throw new TokenMalformedException();
+        }
+        return splitHeaders[1];
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/token/JwtTokenProvider.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/token/JwtTokenProvider.java
@@ -1,0 +1,85 @@
+package com.prokectB.meongbti.authentication.token;
+
+import com.prokectB.meongbti.common.exception.unauthorized.TokenExpiredException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider implements TokenProvider {
+
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private final AuthTokenExtractor authTokenExtractor;
+    private final Key secretKey;
+    private final long validTimeInMilliseconds;
+
+    public JwtTokenProvider(
+            AuthTokenExtractor authTokenExtractor,
+            @Value("${jwt.token.secret}") String secretKey,
+            @Value("${jwt.token.valid-time-in-milliseconds}") long validTimeInMilliseconds) {
+        this.authTokenExtractor = authTokenExtractor;
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.validTimeInMilliseconds = validTimeInMilliseconds;
+    }
+
+    @Override
+    public String createAccessToken(Long id) {
+        Date now = new Date();
+        Date validTime = new Date(now.getTime() + validTimeInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(ACCESS_TOKEN_SUBJECT)
+                .setIssuedAt(now)
+                .setExpiration(validTime)
+                .claim("id", id)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    @Override
+    public boolean isValidToken(String authorizationHeader) {
+        String token = authTokenExtractor.extractToken(authorizationHeader);
+        try {
+            Jws<Claims> claims = getClaims(token);
+            return isAccessToken(claims) && isNotExpired(claims);
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public Long getmemberId(String authorizationHeader) {
+        String token = authTokenExtractor.extractToken(authorizationHeader);
+        try {
+            Claims body = getClaims(token).getBody();
+            return body.get("id", Long.class);
+        } catch (RequiredTypeException | NullPointerException | ExpiredJwtException | IllegalArgumentException e) {
+            throw new TokenExpiredException();
+        }
+    }
+
+
+    private Jws<Claims> getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    private boolean isAccessToken(Jws<Claims> claims) {
+        return claims.getBody()
+                .getSubject()
+                .equals(ACCESS_TOKEN_SUBJECT);
+    }
+
+    private boolean isNotExpired(Jws<Claims> claims) {
+        return claims.getBody()
+                .getExpiration()
+                .after(new Date());
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/token/RefreshToken.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/token/RefreshToken.java
@@ -1,0 +1,33 @@
+package com.prokectB.meongbti.authentication.token;
+
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+public class RefreshToken {
+
+    private String tokenValue;
+    private Long memberId;
+    private LocalDateTime expiredAt;
+   @Builder
+    public RefreshToken(String tokenValue, Long memberId, LocalDateTime expiredAt) {
+        this.tokenValue = tokenValue;
+        this.memberId = memberId;
+        this.expiredAt = expiredAt;
+    }
+
+    public static RefreshToken create(Long memberId, long validTimeInDays) {
+        return new RefreshToken(UUID.randomUUID().toString(), memberId, LocalDateTime.now().plusDays(validTimeInDays));
+    }
+
+
+
+    public boolean isExpired() {
+        return expiredAt.isBefore(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/token/RefreshTokenProvider.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/token/RefreshTokenProvider.java
@@ -1,0 +1,18 @@
+package com.prokectB.meongbti.authentication.token;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefreshTokenProvider {
+
+    private final long validTimeInDays;
+
+    public RefreshTokenProvider(@Value("${token.refresh.valid-time-in-days}") long validTimeInDays) {
+        this.validTimeInDays = validTimeInDays;
+    }
+
+    public RefreshToken createToken(Long memberId) {
+        return RefreshToken.create(memberId, validTimeInDays);
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/token/RefreshTokenRepository.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/token/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.prokectB.meongbti.authentication.token;
+
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+
+    RefreshToken save(RefreshToken refreshToken);
+
+    Optional<RefreshToken> findTokenByTokenValue(String tokenValue);
+
+    void delete(String tokenValue);
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/token/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/token/RefreshTokenRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.prokectB.meongbti.authentication.token;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private static final String TABLE_NAME = "refresh_token";
+    private static final RowMapper<RefreshToken> rowMapper = (rs, rowNum) -> RefreshToken.builder()
+            .tokenValue(rs.getString("token_value"))
+            .expiredAt(rs.getTimestamp("expired_at").toLocalDateTime())
+            .memberId(rs.getLong("user_id"))
+            .build();
+
+    @Override
+    public RefreshToken save(RefreshToken refreshToken) {
+        String sql = String.format(
+                "INSERT INTO %s (token_value, expired_at, user_id)" +
+                        " VALUES (:tokenValue, :expiredAt, :memberId)",
+                TABLE_NAME);
+        BeanPropertySqlParameterSource parameterSource = new BeanPropertySqlParameterSource(refreshToken);
+        int insertCount = namedParameterJdbcTemplate.update(sql, parameterSource);
+        if (insertCount == 1) {
+            return refreshToken;
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Optional<RefreshToken> findTokenByTokenValue(String tokenValue) {
+        String sql = String.format(
+              "SELECT token_value, expired_at, " +
+                      "user_id FROM %s WHERE token_value = :token_value",
+                TABLE_NAME);
+        SqlParameterSource namedParameters = new MapSqlParameterSource("token_value", tokenValue);
+        List<RefreshToken> results = namedParameterJdbcTemplate.query(sql, namedParameters, rowMapper);
+        if (results.size() > 1) {
+            throw new IllegalStateException();
+        }
+        return results.stream().findFirst();
+    }
+
+    @Override
+    public void delete(String tokenValue) {
+        final String sql = String.format(
+                "DELETE FROM %s WHERE token_value = :token_value",
+                TABLE_NAME);
+        SqlParameterSource namedParameters = new MapSqlParameterSource("token_value", tokenValue);
+        int deleteCount = namedParameterJdbcTemplate.update(sql, namedParameters);
+        if (deleteCount != 1) {
+            throw new IllegalStateException();
+        }
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/token/TokenProvider.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/token/TokenProvider.java
@@ -1,0 +1,10 @@
+package com.prokectB.meongbti.authentication.token;
+
+public interface TokenProvider {
+
+    String createAccessToken(Long id);
+
+    boolean isValidToken(String authorizationHeader);
+
+    Long getmemberId(String authorizationHeader);
+}

--- a/src/main/java/com/prokectB/meongbti/common/configuration/advice/CustomException.java
+++ b/src/main/java/com/prokectB/meongbti/common/configuration/advice/CustomException.java
@@ -1,4 +1,4 @@
-package com.prokectB.meongbti.configuration.advice;
+package com.prokectB.meongbti.common.configuration.advice;
 
 
 import lombok.Getter;

--- a/src/main/java/com/prokectB/meongbti/common/configuration/vault/VaultConfig.java
+++ b/src/main/java/com/prokectB/meongbti/common/configuration/vault/VaultConfig.java
@@ -1,4 +1,4 @@
-package com.prokectB.meongbti.configuration.vault;
+package com.prokectB.meongbti.common.configuration.vault;
 
 import com.prokectB.meongbti.common.dto.VaultCredential;
 import com.prokectB.meongbti.common.dto.VaultProps;

--- a/src/main/java/com/prokectB/meongbti/common/configuration/web/WebConfig.java
+++ b/src/main/java/com/prokectB/meongbti/common/configuration/web/WebConfig.java
@@ -1,0 +1,55 @@
+package com.prokectB.meongbti.common.configuration.web;
+
+
+import com.prokectB.meongbti.common.presentation.auth.AuthenticatedMemberResolver;
+import com.prokectB.meongbti.common.presentation.auth.AuthenticationInterceptor;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthenticatedMemberResolver authenticatedMemberResolver;
+    private final AuthenticationInterceptor authenticationInterceptor;
+    private final static String FRONT_END_LOCAL = "http://localhost:3000";
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticatedMemberResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authenticationInterceptor)
+                .addPathPatterns("/api/**");
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedMethods("GET", "POST", "HEAD", "PUT", "PATCH", "DELETE", "TRACE", "OPTIONS")
+                .allowedOrigins(FRONT_END_LOCAL)
+                .allowCredentials(true)
+                .exposedHeaders(LOCATION, SET_COOKIE);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/common/exception/badrequest/InvalidRequestException.java
+++ b/src/main/java/com/prokectB/meongbti/common/exception/badrequest/InvalidRequestException.java
@@ -1,6 +1,6 @@
 package com.prokectB.meongbti.common.exception.badrequest;
 
-import com.prokectB.meongbti.configuration.advice.CustomException;
+import com.prokectB.meongbti.common.configuration.advice.CustomException;
 
 public class InvalidRequestException extends CustomException {
 

--- a/src/main/java/com/prokectB/meongbti/common/exception/forbidden/ForbiddenException.java
+++ b/src/main/java/com/prokectB/meongbti/common/exception/forbidden/ForbiddenException.java
@@ -1,6 +1,6 @@
 package com.prokectB.meongbti.common.exception.forbidden;
 
-import com.prokectB.meongbti.configuration.advice.CustomException;
+import com.prokectB.meongbti.common.configuration.advice.CustomException;
 
 public class ForbiddenException extends CustomException {
 

--- a/src/main/java/com/prokectB/meongbti/common/exception/notfound/MemberNotFoundException.java
+++ b/src/main/java/com/prokectB/meongbti/common/exception/notfound/MemberNotFoundException.java
@@ -1,0 +1,8 @@
+package com.prokectB.meongbti.common.exception.notfound;
+
+public class MemberNotFoundException  extends NotFoundException {
+
+    public MemberNotFoundException() {
+        addValidation("member", "사용자를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/common/exception/notfound/NotFoundException.java
+++ b/src/main/java/com/prokectB/meongbti/common/exception/notfound/NotFoundException.java
@@ -1,6 +1,6 @@
 package com.prokectB.meongbti.common.exception.notfound;
 
-import com.prokectB.meongbti.configuration.advice.CustomException;
+import com.prokectB.meongbti.common.configuration.advice.CustomException;
 
 public class NotFoundException extends CustomException {
 

--- a/src/main/java/com/prokectB/meongbti/common/exception/unauthorized/PasswordMismatchException.java
+++ b/src/main/java/com/prokectB/meongbti/common/exception/unauthorized/PasswordMismatchException.java
@@ -1,0 +1,8 @@
+package com.prokectB.meongbti.common.exception.unauthorized;
+
+public class PasswordMismatchException extends UnauthorizedException {
+
+    public PasswordMismatchException() {
+        addValidation("password", "패스워드가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/common/exception/unauthorized/RefreshTokenNotExistsException.java
+++ b/src/main/java/com/prokectB/meongbti/common/exception/unauthorized/RefreshTokenNotExistsException.java
@@ -1,0 +1,8 @@
+package com.prokectB.meongbti.common.exception.unauthorized;
+
+public class RefreshTokenNotExistsException extends UnauthorizedException {
+
+    public RefreshTokenNotExistsException() {
+        addValidation("refreshToken", "토큰이 존재하지않습니다.");
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/common/exception/unauthorized/TokenMalformedException.java
+++ b/src/main/java/com/prokectB/meongbti/common/exception/unauthorized/TokenMalformedException.java
@@ -1,0 +1,8 @@
+package com.prokectB.meongbti.common.exception.unauthorized;
+
+public class TokenMalformedException extends UnauthorizedException {
+
+    public TokenMalformedException() {
+        addValidation("token", "토큰 형식이 올바르지 않습니다.");
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/common/exception/unauthorized/TokenNotExistsException.java
+++ b/src/main/java/com/prokectB/meongbti/common/exception/unauthorized/TokenNotExistsException.java
@@ -1,0 +1,9 @@
+package com.prokectB.meongbti.common.exception.unauthorized;
+
+
+public class TokenNotExistsException extends UnauthorizedException {
+
+    public TokenNotExistsException() {
+        addValidation("token", "토큰이 존재하지않습니다.");
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/common/exception/unauthorized/UnauthorizedException.java
+++ b/src/main/java/com/prokectB/meongbti/common/exception/unauthorized/UnauthorizedException.java
@@ -1,6 +1,6 @@
 package com.prokectB.meongbti.common.exception.unauthorized;
 
-import com.prokectB.meongbti.configuration.advice.CustomException;
+import com.prokectB.meongbti.common.configuration.advice.CustomException;
 
 public class UnauthorizedException extends CustomException {
 

--- a/src/main/java/com/prokectB/meongbti/common/presentation/CommonControllerAdvice.java
+++ b/src/main/java/com/prokectB/meongbti/common/presentation/CommonControllerAdvice.java
@@ -1,7 +1,7 @@
 package com.prokectB.meongbti.common.presentation;
 
 import com.prokectB.meongbti.common.dto.response.ErrorResponse;
-import com.prokectB.meongbti.configuration.advice.CustomException;
+import com.prokectB.meongbti.common.configuration.advice.CustomException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/src/main/java/com/prokectB/meongbti/common/presentation/auth/AuthController.java
+++ b/src/main/java/com/prokectB/meongbti/common/presentation/auth/AuthController.java
@@ -1,0 +1,46 @@
+package com.prokectB.meongbti.common.presentation.auth;
+
+import com.prokectB.meongbti.authentication.service.AuthService;
+import com.prokectB.meongbti.common.exception.unauthorized.RefreshTokenNotExistsException;
+import com.prokectB.meongbti.common.presentation.auth.common.LoginDto;
+import com.prokectB.meongbti.common.presentation.auth.request.LoginRequest;
+import com.prokectB.meongbti.common.presentation.auth.response.LoginResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.prokectB.meongbti.common.presentation.auth.RefreshTokenCookieProvider.REFRESH_TOKEN;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    private final RefreshTokenCookieProvider refreshTokenCookieProvider;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
+        LoginDto loginDto = authService.login(loginRequest.getEmail(), loginRequest.getPassword());
+        ResponseCookie cookie = refreshTokenCookieProvider.createCookie(loginDto.getRefreshToken());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(LoginResponse.from(loginDto.getAccessToken()));
+    }
+
+    @GetMapping("/logout")
+    public ResponseEntity<Void> logout(@CookieValue(value = REFRESH_TOKEN, required = false) String refreshToken) {
+        validateRefreshTokenExists(refreshToken);
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookieProvider.createLogoutCookie().toString())
+                .build();
+    }
+
+    private void validateRefreshTokenExists(final String refreshToken) {
+        if (refreshToken == null) {
+            throw new RefreshTokenNotExistsException();
+        }
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/common/presentation/auth/AuthenticatedMember.java
+++ b/src/main/java/com/prokectB/meongbti/common/presentation/auth/AuthenticatedMember.java
@@ -1,0 +1,11 @@
+package com.prokectB.meongbti.common.presentation.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticatedMember {
+}

--- a/src/main/java/com/prokectB/meongbti/common/presentation/auth/AuthenticatedMemberResolver.java
+++ b/src/main/java/com/prokectB/meongbti/common/presentation/auth/AuthenticatedMemberResolver.java
@@ -1,0 +1,40 @@
+package com.prokectB.meongbti.common.presentation.auth;
+
+import com.prokectB.meongbti.authentication.token.TokenProvider;
+import com.prokectB.meongbti.common.exception.unauthorized.TokenExpiredException;
+import com.prokectB.meongbti.common.exception.unauthorized.TokenNotExistsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticatedMemberResolver implements HandlerMethodArgumentResolver {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticatedMember.class);
+    }
+
+
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        String authorizationHeader = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authorizationHeader == null) {
+            throw new TokenNotExistsException();
+        }
+        if (tokenProvider.isValidToken(authorizationHeader)) {
+            return tokenProvider.getmemberId(authorizationHeader);
+        }
+        throw new TokenExpiredException();
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/common/presentation/auth/AuthenticationInterceptor.java
+++ b/src/main/java/com/prokectB/meongbti/common/presentation/auth/AuthenticationInterceptor.java
@@ -1,0 +1,55 @@
+package com.prokectB.meongbti.common.presentation.auth;
+
+import com.prokectB.meongbti.authentication.token.TokenProvider;
+import com.prokectB.meongbti.common.exception.unauthorized.TokenExpiredException;
+import com.prokectB.meongbti.common.exception.unauthorized.TokenNotExistsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        Login auth = getLoginAnnotation(handler);
+        if (!(handler instanceof HandlerMethod) || auth == null) {
+            return true;
+        }
+
+        if (request.getHeader(AUTHORIZATION) != null) {
+            validateToken(request);
+            return true;
+        }
+
+        validateTokenRequired(auth);
+        return true;
+    }
+
+    private void validateTokenRequired(Login auth) {
+        if (auth.required()) {
+            throw new TokenNotExistsException();
+        }
+    }
+
+    private void validateToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(AUTHORIZATION);
+        if (!tokenProvider.isValidToken(authorizationHeader)) {
+            throw new TokenExpiredException();
+        }
+    }
+
+    private Login getLoginAnnotation(Object handler) {
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        return handlerMethod.getMethodAnnotation(Login.class);
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/common/presentation/auth/Login.java
+++ b/src/main/java/com/prokectB/meongbti/common/presentation/auth/Login.java
@@ -1,0 +1,13 @@
+package com.prokectB.meongbti.common.presentation.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+
+    boolean required() default true;
+}

--- a/src/main/java/com/prokectB/meongbti/common/presentation/auth/RefreshTokenCookieProvider.java
+++ b/src/main/java/com/prokectB/meongbti/common/presentation/auth/RefreshTokenCookieProvider.java
@@ -1,0 +1,42 @@
+package com.prokectB.meongbti.common.presentation.auth;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.server.Cookie.SameSite;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseCookie.ResponseCookieBuilder;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class RefreshTokenCookieProvider {
+
+    protected static final String REFRESH_TOKEN = "refreshToken";
+    private static final int REMOVAL_MAX_AGE = 0;
+
+    private final long validTimeInDays;
+
+    public RefreshTokenCookieProvider(@Value("${token.refresh.valid-time-in-days}") long validTimeInDays) {
+        this.validTimeInDays = validTimeInDays;
+    }
+
+    public ResponseCookie createCookie(final String refreshToken) {
+        return createTokenCookieBuilder(refreshToken)
+                .maxAge(Duration.ofDays(validTimeInDays))
+                .build();
+    }
+
+    public ResponseCookie createLogoutCookie() {
+        return createTokenCookieBuilder("")
+                .maxAge(REMOVAL_MAX_AGE)
+                .build();
+    }
+
+    private ResponseCookieBuilder createTokenCookieBuilder(final String value) {
+        return ResponseCookie.from(REFRESH_TOKEN, value)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite(SameSite.NONE.attributeValue());
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/common/presentation/auth/common/LoginDto.java
+++ b/src/main/java/com/prokectB/meongbti/common/presentation/auth/common/LoginDto.java
@@ -1,0 +1,23 @@
+package com.prokectB.meongbti.common.presentation.auth.common;
+
+
+import lombok.Builder;
+import lombok.Data;
+
+
+@Data
+public class LoginDto {
+
+    String accessToken;
+    String refreshToken;
+
+    @Builder
+    public LoginDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public static LoginDto create(String accessToken, String refreshToken) {
+        return new LoginDto(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/common/presentation/auth/request/LoginRequest.java
+++ b/src/main/java/com/prokectB/meongbti/common/presentation/auth/request/LoginRequest.java
@@ -1,0 +1,19 @@
+package com.prokectB.meongbti.common.presentation.auth.request;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+
+    String email;
+
+    String password;
+
+    @Builder
+    public LoginRequest(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+}

--- a/src/main/java/com/prokectB/meongbti/common/presentation/auth/response/LoginResponse.java
+++ b/src/main/java/com/prokectB/meongbti/common/presentation/auth/response/LoginResponse.java
@@ -1,0 +1,20 @@
+package com.prokectB.meongbti.common.presentation.auth.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class LoginResponse {
+
+    String accessToken;
+
+    @Builder
+    public LoginResponse(String accessToken) {
+            this.accessToken = accessToken;
+    }
+
+    public static LoginResponse from(String accessToken) {
+        return new LoginResponse(accessToken);
+    }
+
+}

--- a/src/main/java/com/prokectB/meongbti/member/entity/Member.java
+++ b/src/main/java/com/prokectB/meongbti/member/entity/Member.java
@@ -1,0 +1,29 @@
+package com.prokectB.meongbti.member.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String email;
+
+    private String password;
+
+    @Builder
+    public Member(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/member/repository/MemberRepository.java
+++ b/src/main/java/com/prokectB/meongbti/member/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.prokectB.meongbti.member.repository;
+
+import com.prokectB.meongbti.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,6 @@
+create table if not exists refresh_token
+(
+    token_value varchar(255) primary key,
+    expired_at  timestamp not null,
+    member_id   bigint    not null
+);


### PR DESCRIPTION
작업 주제
-------------------

JWT 토큰 인증 과정을 구현합니다.

작업 내용
-----------------------

- JWT token 의 Access Token과 RefreshToken을 이용하여 인증, 인가 과정을 구현했습니다.

- 로그인 기능을 구현했습니다. 로그인시 Access Token과 Refresh Token을 발급합니다. Refresh Token은 Cookie를 통해 보관할 수 있도록 했습니다.

- Refresh Token의 저장소는 현재 RDB에 저장하도록 구현해놨습니다 Jpa Entity에서 관리되지 않도록 JdbcTemplate로 DB로직을 구현해 논 상태입니다. 추후에 토큰 저장소의 변경이 있을 경우 확장 할 수 있도록 설계했습니다.

- 추후에 인증, 인가가 필요한 로직에 대해 인증이 진행 될 수 있도록 Spring Security를 이용하지 않고 Interceptor와 Resolver로 처리하여 어노테이션으로 인증, 유저 데이터를 가져 올 수 있도록 구현했습니다.

- Spring Security를 이용하는 것도 좋지만 현재 프로젝트에서는 관리자 기능 등 불필요한 라이브러리가 많다고 판단되어 Spring Security에서 cypto 라이브러리 설정해 사용하여 비밀번호 암호화만 사용하도록 했습니다.

- 기본적인 테스트는 모두 진행할 수 있도록 했고, rest-docs test를 따로 진행하여 API문서를 만들고 있습니다.