### PR TITLE
feat:  kakao login 구현

### DIFF
--- a/src/main/java/com/prokectB/meongbti/authentication/controller/AuthController.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/controller/AuthController.java
@@ -2,6 +2,9 @@ package com.prokectB.meongbti.authentication.controller;
 
 import com.prokectB.meongbti.authentication.dto.LoginDto;
 
+import com.prokectB.meongbti.authentication.oauth.token.AuthTokens;
+import com.prokectB.meongbti.authentication.oauth.KakaoLoginParams;
+import com.prokectB.meongbti.authentication.oauth.service.OAuthLoginService;
 import com.prokectB.meongbti.authentication.response.AccessTokenResponse;
 import com.prokectB.meongbti.authentication.service.AuthService;
 import com.prokectB.meongbti.common.exception.unauthorized.RefreshTokenNotExistsException;
@@ -23,7 +26,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final RefreshTokenCookieProvider refreshTokenCookieProvider;
-
+    private final OAuthLoginService oAuthLoginService;
     @PostMapping("/login")
     public ResponseEntity<AccessTokenResponse> login(@RequestBody LoginRequest loginRequest) {
         LoginDto loginDto = authService.login(loginRequest.getEmail(), loginRequest.getPassword());
@@ -60,4 +63,11 @@ public class AuthController {
             throw new RefreshTokenNotExistsException();
         }
     }
+
+    @PostMapping("/kakao")
+    public ResponseEntity<AuthTokens> loginKakao(@RequestBody KakaoLoginParams params) {
+        return ResponseEntity.ok(oAuthLoginService.login(params));
+    }
+
+
 }

--- a/src/main/java/com/prokectB/meongbti/authentication/oauth/KakaoApiClient.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/oauth/KakaoApiClient.java
@@ -1,0 +1,71 @@
+package com.prokectB.meongbti.authentication.oauth;
+
+import com.prokectB.meongbti.authentication.oauth.token.KakaoTokens;
+import com.prokectB.meongbti.member.entity.OAuthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoApiClient implements OAuthApiClient {
+
+    private static final String GRANT_TYPE = "authorization_code";
+
+    @Value("${oauth.kakao.url.auth}")
+    private String authUrl;
+
+    @Value("${oauth.kakao.url.api}")
+    private String apiUrl;
+
+    @Value("${oauth.kakao.client-id}")
+    private String clientId;
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public OAuthProvider oAuthProvider() {
+        return OAuthProvider.KAKAO;
+    }
+
+    @Override
+    public String requestAccessToken(OAuthLoginParams params) {
+        String url = authUrl + "/oauth/token";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = params.makeBody();
+        body.add("grant_type", GRANT_TYPE);
+        body.add("client_id", clientId);
+
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+
+        KakaoTokens response = restTemplate.postForObject(url, request, KakaoTokens.class);
+
+        assert response != null;
+        return response.getAccessToken();
+    }
+
+    @Override
+    public OAuthInfoResponse requestOauthInfo(String accessToken) {
+        String url = apiUrl + "/v2/user/me";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        httpHeaders.set("Authorization", "Bearer " + accessToken);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("property_keys", "[\"kakao_account.email\", \"kakao_account.profile\"]");
+
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+
+        return restTemplate.postForObject(url, request, KakaoInfoResponse.class);
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/oauth/KakaoInfoResponse.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/oauth/KakaoInfoResponse.java
@@ -1,0 +1,42 @@
+package com.prokectB.meongbti.authentication.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.prokectB.meongbti.member.entity.OAuthProvider;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoInfoResponse implements OAuthInfoResponse {
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class KakaoAccount {
+        private KakaoProfile profile;
+        private String email;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class KakaoProfile {
+        private String nickname;
+    }
+
+    @Override
+    public String getEmail() {
+        return kakaoAccount.email;
+    }
+
+    @Override
+    public String getNickname() {
+        return kakaoAccount.profile.nickname;
+    }
+
+    @Override
+    public OAuthProvider getOAuthProvider() {
+        return OAuthProvider.KAKAO;
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/oauth/KakaoLoginParams.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/oauth/KakaoLoginParams.java
@@ -1,0 +1,25 @@
+package com.prokectB.meongbti.authentication.oauth;
+
+import com.prokectB.meongbti.member.entity.OAuthProvider;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Getter
+@NoArgsConstructor
+public class KakaoLoginParams implements OAuthLoginParams {
+    private String authorizationCode;
+
+    @Override
+    public OAuthProvider oAuthProvider() {
+        return OAuthProvider.KAKAO;
+    }
+
+    @Override
+    public MultiValueMap<String, String> makeBody() {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", authorizationCode);
+        return body;
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/oauth/OAuthApiClient.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/oauth/OAuthApiClient.java
@@ -1,0 +1,9 @@
+package com.prokectB.meongbti.authentication.oauth;
+
+import com.prokectB.meongbti.member.entity.OAuthProvider;
+
+public interface OAuthApiClient {
+    OAuthProvider oAuthProvider();
+    String requestAccessToken(OAuthLoginParams params);
+    OAuthInfoResponse requestOauthInfo(String accessToken);
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/oauth/OAuthInfoResponse.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/oauth/OAuthInfoResponse.java
@@ -1,0 +1,9 @@
+package com.prokectB.meongbti.authentication.oauth;
+
+import com.prokectB.meongbti.member.entity.OAuthProvider;
+
+public interface OAuthInfoResponse {
+    String getEmail();
+    String getNickname();
+    OAuthProvider getOAuthProvider();
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/oauth/OAuthLoginParams.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/oauth/OAuthLoginParams.java
@@ -1,0 +1,9 @@
+package com.prokectB.meongbti.authentication.oauth;
+
+import com.prokectB.meongbti.member.entity.OAuthProvider;
+import org.springframework.util.MultiValueMap;
+
+public interface OAuthLoginParams {
+    OAuthProvider oAuthProvider();
+    MultiValueMap<String, String> makeBody();
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/oauth/RequestOAuthInfoService.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/oauth/RequestOAuthInfoService.java
@@ -1,0 +1,27 @@
+package com.prokectB.meongbti.authentication.oauth;
+
+import com.prokectB.meongbti.member.entity.OAuthProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class RequestOAuthInfoService {
+    private final Map<OAuthProvider, OAuthApiClient> clients;
+
+    public RequestOAuthInfoService(List<OAuthApiClient> clients) {
+        this.clients = clients.stream().collect(
+                Collectors.toUnmodifiableMap(OAuthApiClient::oAuthProvider,
+                        Function.identity())
+        );
+    }
+
+    public OAuthInfoResponse request(OAuthLoginParams params) {
+        OAuthApiClient client = clients.get(params.oAuthProvider());
+        String accessToken = client.requestAccessToken(params);
+        return client.requestOauthInfo(accessToken);
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/oauth/config/ClientConfig.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/oauth/config/ClientConfig.java
@@ -1,0 +1,14 @@
+package com.prokectB.meongbti.authentication.oauth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class ClientConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/oauth/service/OAuthLoginService.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/oauth/service/OAuthLoginService.java
@@ -1,0 +1,41 @@
+package com.prokectB.meongbti.authentication.oauth.service;
+
+import com.prokectB.meongbti.authentication.oauth.token.AuthTokensGenerator;
+import com.prokectB.meongbti.authentication.oauth.OAuthInfoResponse;
+import com.prokectB.meongbti.authentication.oauth.OAuthLoginParams;
+import com.prokectB.meongbti.authentication.oauth.RequestOAuthInfoService;
+import com.prokectB.meongbti.authentication.oauth.token.AuthTokens;
+import com.prokectB.meongbti.member.entity.Member;
+import com.prokectB.meongbti.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthLoginService {
+    private final MemberRepository memberRepository;
+    private final AuthTokensGenerator authTokensGenerator;
+    private final RequestOAuthInfoService requestOAuthInfoService;
+
+    public AuthTokens login(OAuthLoginParams params) {
+        OAuthInfoResponse oAuthInfoResponse = requestOAuthInfoService.request(params);
+        Long memberId = findOrCreateMember(oAuthInfoResponse);
+        return authTokensGenerator.generate(memberId);
+    }
+
+    private Long findOrCreateMember(OAuthInfoResponse oAuthInfoResponse) {
+        return memberRepository.findByEmail(oAuthInfoResponse.getEmail())
+                .map(Member::getId)
+                .orElseGet(() -> newMember(oAuthInfoResponse));
+    }
+
+    private Long newMember(OAuthInfoResponse oAuthInfoResponse) {
+        Member member = Member.builder()
+                .email(oAuthInfoResponse.getEmail())
+                .nickname(oAuthInfoResponse.getNickname())
+                .oAuthProvider(oAuthInfoResponse.getOAuthProvider())
+                .build();
+
+        return memberRepository.save(member).getId();
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/oauth/token/AuthTokens.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/oauth/token/AuthTokens.java
@@ -1,0 +1,21 @@
+package com.prokectB.meongbti.authentication.oauth.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthTokens {
+    private String accessToken;
+    private String refreshToken;
+    private String grantType;
+    private Long expiresIn;
+
+    public static AuthTokens of(String accessToken, String refreshToken, String grantType, Long expiresIn) {
+        return new AuthTokens(accessToken, refreshToken, grantType, expiresIn);
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/oauth/token/AuthTokensGenerator.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/oauth/token/AuthTokensGenerator.java
@@ -1,0 +1,35 @@
+package com.prokectB.meongbti.authentication.oauth.token;
+
+import com.prokectB.meongbti.authentication.oauth.token.AuthTokens;
+import com.prokectB.meongbti.authentication.token.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class AuthTokensGenerator {
+    private static final String BEARER_TYPE = "Bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+
+    public AuthTokens generate(Long memberId) {
+        long now = (new Date()).getTime();
+        Date accessTokenExpiredAt = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        Date refreshTokenExpiredAt = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
+
+        String subject = memberId.toString();
+        String accessToken = jwtTokenProvider.generate(subject, accessTokenExpiredAt);
+        String refreshToken = jwtTokenProvider.generate(subject, refreshTokenExpiredAt);
+
+        return AuthTokens.of(accessToken, refreshToken, BEARER_TYPE, ACCESS_TOKEN_EXPIRE_TIME / 1000L);
+    }
+
+    public Long extractMemberId(String accessToken) {
+        return Long.valueOf(jwtTokenProvider.extractSubject(accessToken));
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/oauth/token/KakaoTokens.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/oauth/token/KakaoTokens.java
@@ -1,0 +1,28 @@
+package com.prokectB.meongbti.authentication.oauth.token;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokens {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private String expiresIn;
+
+    @JsonProperty("refresh_token_expires_in")
+    private String refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/com/prokectB/meongbti/authentication/token/JwtTokenProvider.java
+++ b/src/main/java/com/prokectB/meongbti/authentication/token/JwtTokenProvider.java
@@ -41,6 +41,31 @@ public class JwtTokenProvider implements TokenProvider {
                 .compact();
     }
 
+    public String generate(String subject, Date expiredAt) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .setExpiration(expiredAt)
+                .signWith(secretKey, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public String extractSubject(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+        return claims.getSubject();
+    }
+
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
     @Override
     public boolean isValidToken(String authorizationHeader) {
         String token = authTokenExtractor.extractToken(authorizationHeader);

--- a/src/main/java/com/prokectB/meongbti/member/dto/response/UserResponse.java
+++ b/src/main/java/com/prokectB/meongbti/member/dto/response/UserResponse.java
@@ -1,0 +1,26 @@
+package com.prokectB.meongbti.member.dto.response;
+
+import com.prokectB.meongbti.member.entity.Member;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class UserResponse {
+    private Long id;
+    private String nickname;
+    private String email;
+    private LocalDateTime joinedAt;
+
+    public UserResponse(Long id, String nickname, String email, LocalDateTime joinedAt) {
+        this.id = id;
+        this.nickname = nickname;
+        this.email = email;
+        this.joinedAt = joinedAt;
+    }
+
+    public static UserResponse create(Member member) {
+        return new UserResponse(member.getId(), member.getNickname(),
+                member.getEmail(), member.getJoinedAt());
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/member/entity/Member.java
+++ b/src/main/java/com/prokectB/meongbti/member/entity/Member.java
@@ -4,10 +4,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -19,11 +20,32 @@ public class Member {
 
     private String email;
 
+    private String nickname;
+
     private String password;
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime joinedAt;
+
+    @PrePersist
+    private void onPrePersist() {
+        this.joinedAt = LocalDateTime.now();
+    }
 
     @Builder
-    public Member(String email, String password) {
+    public Member(String email, String password, String nickname) {
         this.email = email;
         this.password = password;
+        this.nickname = nickname;
+
+    }
+
+    public static Member create(String email, String encodedPassword, String nickname) {
+        return Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .password(encodedPassword)
+
+                .build();
     }
 }

--- a/src/main/java/com/prokectB/meongbti/member/entity/Member.java
+++ b/src/main/java/com/prokectB/meongbti/member/entity/Member.java
@@ -23,6 +23,8 @@ public class Member {
     private String nickname;
 
     private String password;
+
+    private OAuthProvider oAuthProvider;
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime joinedAt;
@@ -33,10 +35,11 @@ public class Member {
     }
 
     @Builder
-    public Member(String email, String password, String nickname) {
+    public Member(String email, String password, String nickname, OAuthProvider oAuthProvider) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
+        this.oAuthProvider = oAuthProvider;
 
     }
 

--- a/src/main/java/com/prokectB/meongbti/member/entity/OAuthProvider.java
+++ b/src/main/java/com/prokectB/meongbti/member/entity/OAuthProvider.java
@@ -1,0 +1,5 @@
+package com.prokectB.meongbti.member.entity;
+
+public enum OAuthProvider {
+    KAKAO
+}

--- a/src/main/java/com/prokectB/meongbti/member/repository/MemberRepository.java
+++ b/src/main/java/com/prokectB/meongbti/member/repository/MemberRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNickname(String nickName);
 }

--- a/src/main/java/com/prokectB/meongbti/member/service/MemberReadService.java
+++ b/src/main/java/com/prokectB/meongbti/member/service/MemberReadService.java
@@ -1,0 +1,21 @@
+package com.prokectB.meongbti.member.service;
+
+import com.prokectB.meongbti.common.exception.notfound.MemberNotFoundException;
+import com.prokectB.meongbti.member.entity.Member;
+import com.prokectB.meongbti.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberReadService {
+
+    private final MemberRepository memberRepository;
+
+    public Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+}

--- a/src/main/java/com/prokectB/meongbti/member/service/MemberWriteService.java
+++ b/src/main/java/com/prokectB/meongbti/member/service/MemberWriteService.java
@@ -1,0 +1,45 @@
+package com.prokectB.meongbti.member.service;
+
+import com.prokectB.meongbti.common.exception.badrequest.DuplicatedUserException;
+import com.prokectB.meongbti.member.controller.request.UserJoinRequest;
+import com.prokectB.meongbti.member.dto.response.UserResponse;
+import com.prokectB.meongbti.member.entity.Member;
+import com.prokectB.meongbti.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberWriteService {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserResponse join(UserJoinRequest userJoinRequest) {
+        validateDuplicateEmail(userJoinRequest.getEmail());
+        validateDuplicateNickname(userJoinRequest.getNickname());
+        String encodedPassword = passwordEncoder.encode(userJoinRequest.getPassword());
+
+        Member newUser = Member.create(userJoinRequest.getEmail(), encodedPassword, userJoinRequest.getNickname());
+        memberRepository.save(newUser);
+        return UserResponse.create(newUser);
+    }
+
+    private void validateDuplicateEmail(String email) {
+        Optional<Member> DuplicatedUser = memberRepository.findByEmail(email);
+        if (DuplicatedUser.isPresent()) {
+            throw new DuplicatedUserException();
+        }
+    }
+
+    private void validateDuplicateNickname(String nickName) {
+        Optional<Member> DuplicatedUser = memberRepository.findByNickname(nickName);
+        if (DuplicatedUser.isPresent()) {
+            throw new DuplicatedUserException();
+        }
+    }
+}

--- a/src/test/java/com/prokectB/meongbti/member/MemberWriteServiceTest.java
+++ b/src/test/java/com/prokectB/meongbti/member/MemberWriteServiceTest.java
@@ -1,0 +1,76 @@
+package com.prokectB.meongbti.member;
+
+import com.prokectB.meongbti.common.exception.badrequest.DuplicatedUserException;
+import com.prokectB.meongbti.member.controller.request.UserJoinRequest;
+import com.prokectB.meongbti.member.dto.response.UserResponse;
+import com.prokectB.meongbti.member.entity.Member;
+import com.prokectB.meongbti.member.repository.MemberRepository;
+import com.prokectB.meongbti.member.service.MemberWriteService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserWriteServiceTest {
+
+    @InjectMocks
+    private MemberWriteService memberWriteService  ;
+
+    @Mock
+    private MemberRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+
+    @Test
+    @DisplayName("회원가입이 완료되어야한다.")
+    void join_shouldReturnCreatedUserResponse() {
+        UserJoinRequest userJoinRequest = new UserJoinRequest("testuser@gmail.com", "password", "testuser");
+        String encodedPassword = "encodedPassword";
+        String nickname = "testuser";
+        Member newUser = Member.create(userJoinRequest.getEmail(), encodedPassword, nickname);
+        Member savedUser = Member.create("testuser@gmail.com", encodedPassword, nickname);
+        when(passwordEncoder.encode(userJoinRequest.getPassword())).thenReturn(encodedPassword);
+        when(userRepository.findByNickname("testuser")).thenReturn(Optional.empty());
+        when(userRepository.save(any(Member.class))).thenReturn(savedUser);
+
+        UserResponse userResponse = memberWriteService.join(userJoinRequest);
+
+        assertEquals(newUser.getEmail(), userResponse.getEmail());
+        assertEquals(newUser.getNickname(), userResponse.getNickname());
+    }
+
+    @Test
+    @DisplayName("중복된 닉네임이 존재하면 DuplicatedUserException이 발생한다.")
+    void join_duplicatedUser() {
+        UserJoinRequest userJoinRequest = new UserJoinRequest("testuser@gmail.com", "password", "testuser");
+
+        Member duplicatedUser = Member.create("testuser@gmail.com", "passwrod", "testuser");
+        when(userRepository.findByNickname("testuser")).thenReturn(Optional.of(duplicatedUser));
+
+        assertThrows(DuplicatedUserException.class, () -> memberWriteService.join(userJoinRequest));
+    }
+
+    @Test
+    @DisplayName("중복된 이메일 존재하면 DuplicatedUserException이 발생한다.")
+    void join_EmailduplicatedUser() {
+        UserJoinRequest userJoinRequest = new UserJoinRequest("testuser@gmail.com", "password", "testuser");
+
+        Member duplicatedUser = Member.create("testuser@gmail.com", "passwrod", "testuser");
+        when(userRepository.findByEmail("testuser@gmail.com")).thenReturn(Optional.of(duplicatedUser));
+
+        assertThrows(DuplicatedUserException.class, () -> memberWriteService.join(userJoinRequest));
+    }
+}


### PR DESCRIPTION
작업주제
--------------
- Kakao login 구현

작업 내용
------------------
- 카카오 인가 코드를 요청하면 해당되는 access token, refresh token을 내려줍니다
- 카카오 서버에서 받은 nickname, email은 rds로 저장됩니다 